### PR TITLE
bugfix: do288 (OCP 4.2) lab ch10s03: todo-backend

### DIFF
--- a/todo-backend/package.json
+++ b/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "todo-single",
-  "description": "single container version of the todoapp",
+  "name": "todo-backend",
+  "description": "multi-container version of the todoapp",
   "version": "0.0.2",
   "private": true,
   "author": "Red Hat Training",
@@ -9,7 +9,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "restify": "4.0.3",
+    "restify": "4.3.0",
     "sequelize": "3.14.2",
     "mysql": "2.9.0"
   }


### PR DESCRIPTION
The "todo-backend" application fails to start in the current
version of the do288 OCP 4.2 course, which prevents completion
of the lab "Containerizing and Deploying a Service" in chapter
10, section 3.

This "todo-backend" application's "package.json" file appears to
have been copied from a previous lab ("todo-single"), but the
version number of the "restify" depdency has been transposed from
"4.3.0" (working) to "4.0.3" (broken).

This commit enables this lab to be completed successfully.