### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube

### DIFF
--- a/todo-api-micro/pom.xml
+++ b/todo-api-micro/pom.xml
@@ -29,7 +29,7 @@
     <version.compiler.plugin>3.1</version.compiler.plugin>
     <version.surefire.plugin>2.16</version.surefire.plugin>
     <version.war.plugin>2.5</version.war.plugin>
-    <version.fabric8.plugin>4.1.0</version.fabric8.plugin>
+    <jkube.version>1.3.0</jkube.version>
 
     <!-- maven-compiler-plugin -->
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -107,12 +107,12 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>${version.fabric8.plugin}</version>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+        <version>${jkube.version}</version>
         <executions>
           <execution>
-            <id>fmp</id>
+            <id>jkube</id>
             <goals>
               <goal>resource</goal>
               <goal>build</goal>


### PR DESCRIPTION
Migrate fabric8-maven-plugin to Eclipse JKube's openshift-maven-plugin.

Eclipse JKube is the successor to Fabric8 Maven Plugin. We encourage using
Eclipse JKube instead of FMP since support for FMP would be eventually
dropped in future.