### PR TITLE
run pip freeze against the architecture-setup app

### DIFF
--- a/labs/architecture-setup/hello-flask/requirements.txt
+++ b/labs/architecture-setup/hello-flask/requirements.txt
@@ -1,3 +1,10 @@
 -i http://nexus-infra.apps.ocp4.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.ocp4.example.com
 Flask==2.1.0
 gunicorn==20.1.0
+click==8.1.7
+importlib-metadata==6.8.0
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+Werkzeug==3.0.0
+zipp==3.17.0

--- a/labs/architecture-setup/hello-flask/requirements.txt
+++ b/labs/architecture-setup/hello-flask/requirements.txt
@@ -6,5 +6,5 @@ importlib-metadata==6.8.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.3
-Werkzeug==3.0.0
+Werkzeug==2.3.7
 zipp==3.17.0


### PR DESCRIPTION
To get the dependencies run something along these lines:

```bash
podman run -it --privileged -v /home/asernabo/RHT/DO288-apps/labs/architecture-setup/hello-flask/requirements.txt:/reqs.txt  registry.ocp4.example.com:8443/ubi8/python-39 sh -c "pip install -r /reqs.txt;  pip freeze -r /reqs.txt"
```