### PR TITLE
apiVersion changes re PTL-11267

### DIFF
--- a/kubefiles/pipelines-review/gradedrun.yaml
+++ b/kubefiles/pipelines-review/gradedrun.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: gradedrun

--- a/labs/compreview-cicd/npm-task.yaml
+++ b/labs/compreview-cicd/npm-task.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: npm

--- a/labs/compreview-cicd/pipeline.yaml
+++ b/labs/compreview-cicd/pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: words-cicd-pipeline

--- a/labs/pipelines-creation/npm-task.yaml
+++ b/labs/pipelines-creation/npm-task.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: npm

--- a/labs/pipelines-creation/pipeline.yaml
+++ b/labs/pipelines-creation/pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: nodejs-build

--- a/labs/pipelines-review/pipeline.yaml
+++ b/labs/pipelines-review/pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: maven-java-pipeline

--- a/labs/pipelines-review/run.yaml
+++ b/labs/pipelines-review/run.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: testrun

--- a/labs/pipelines-review/task.yaml
+++ b/labs/pipelines-review/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: maven-task

--- a/solutions/compreview-cicd/pipeline.yaml
+++ b/solutions/compreview-cicd/pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: words-cicd-pipeline

--- a/solutions/pipelines-creation/npm-task.yaml
+++ b/solutions/pipelines-creation/npm-task.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: npm

--- a/solutions/pipelines-creation/pipeline.yaml
+++ b/solutions/pipelines-creation/pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: nodejs-build

--- a/solutions/pipelines-review/pipeline.yaml
+++ b/solutions/pipelines-review/pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: maven-java-pipeline

--- a/solutions/pipelines-review/task.yaml
+++ b/solutions/pipelines-review/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: maven-task


### PR DESCRIPTION
Closes PTL-11267.

Changed API versions of all tasks, pipelines, and runs that were using the v1beta1 to v1.