### PR TITLE
fix(PTL-13428): ch7lab: PipelineRun uses legacy serviceAccountName attribute

### DIFF
--- a/kubefiles/pipelines-review/gradedrun.yaml
+++ b/kubefiles/pipelines-review/gradedrun.yaml
@@ -20,7 +20,8 @@ spec:
       value: graded-app
   pipelineRef:
     name: maven-java-pipeline
-  serviceAccountName: pipeline
+  taskRunTemplate:
+    serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
     - name: shared

--- a/labs/pipelines-review/run.yaml
+++ b/labs/pipelines-review/run.yaml
@@ -20,7 +20,8 @@ spec:
       value: vertx-site
   pipelineRef:
     name: maven-java-pipeline
-  serviceAccountName: pipeline
+  taskRunTemplate:
+    serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:
     - name: shared


### PR DESCRIPTION
Closes PTL-13428.

fixed serviceAccountName attribute of PipelineRun resources