### PR TITLE
fix(PTL-13429): ch7lab: PipelineRun uses legacy timeout attribute in grading

### DIFF
--- a/kubefiles/pipelines-review/gradedrun.yaml
+++ b/kubefiles/pipelines-review/gradedrun.yaml
@@ -21,7 +21,9 @@ spec:
   pipelineRef:
     name: maven-java-pipeline
   serviceAccountName: pipeline
-  timeout: 1h0m0s
+  timeouts:
+    pipeline: 1h0m0s
+    tasks: 0h15m0s
   workspaces:
     - name: shared
       volumeClaimTemplate:


### PR DESCRIPTION
Closes PTL-13429.

fixed the timeout attribute to use the new schema