### PR TITLE
Removed timeout field

### DIFF
--- a/labs/pipelines-review/run.yaml
+++ b/labs/pipelines-review/run.yaml
@@ -22,7 +22,6 @@ spec:
     name: maven-java-pipeline
   taskRunTemplate:
     serviceAccountName: pipeline
-  timeout: 1h0m0s
   workspaces:
     - name: shared
       volumeClaimTemplate:


### PR DESCRIPTION
The api version for Tetkton changed, and now we can't use the timeout field in the place we have it.