### PR TITLE
fix: add missing go.mod file for DO288 exercise

### DIFF
--- a/go-hello/go.mod
+++ b/go-hello/go.mod
@@ -1,0 +1,3 @@
+module go-hello
+
+go 1.18


### PR DESCRIPTION
Added missing go.mod file that was preventing completion of DO288 book exercise and proper usage of Go builder