### PR TITLE
Fix PyPI index URL in requirements.txt files

### DIFF
--- a/apps/deploy-cli/weather-app/requirements.txt
+++ b/apps/deploy-cli/weather-app/requirements.txt
@@ -1,4 +1,4 @@
--i http://nexus-infra.apps.ocp4.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.ocp4.example.com
+-i http://nexus-infra.apps.lab.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.lab.example.com
 click==8.1.3
 Flask==2.3.2
 gunicorn==20.1.0

--- a/labs/architecture-setup/hello-flask/requirements.txt
+++ b/labs/architecture-setup/hello-flask/requirements.txt
@@ -1,4 +1,4 @@
--i http://nexus-infra.apps.ocp4.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.ocp4.example.com
+-i http://nexus-infra.apps.lab.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.lab.example.com
 Flask==2.1.0
 gunicorn==20.1.0
 click==8.1.7

--- a/labs/deploy-cli/weather/requirements.txt
+++ b/labs/deploy-cli/weather/requirements.txt
@@ -1,4 +1,4 @@
--i http://nexus-infra.apps.ocp4.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.ocp4.example.com
+-i http://nexus-infra.apps.lab.example.com/repository/pypi/simple --trusted-host nexus-infra.apps.lab.example.com
 click==8.1.3
 Flask==2.3.2
 gunicorn==20.1.0


### PR DESCRIPTION
## Summary
- Update PyPI index URL from `apps.ocp4.example.com` to `apps.lab.example.com` in all requirements.txt files
- The cluster domain changed from `ocp4` to `lab`, so pip was failing with NXDOMAIN when trying to resolve the old hostname
- Affects: `apps/deploy-cli/weather-app`, `labs/architecture-setup/hello-flask`, `labs/deploy-cli/weather`

## Test plan
- Run `pip install -r requirements.txt` from within the lab environment and confirm packages resolve from `nexus-infra.apps.lab.example.com`

Made with [Cursor](https://cursor.com)