### PR TITLE
feat: CDEV-18238 Bump deployments-health to 4.22

### DIFF
--- a/labs/deployments-health/application.yaml
+++ b/labs/deployments-health/application.yaml
@@ -19,7 +19,7 @@ spec:
         deployment: expense
     spec:
       containers:
-      - image: registry.lab.example.com:8443/redhattraining/ocpdev-expense-service-health:4.18
+      - image: registry.lab.example.com:8443/redhattraining/ocpdev-expense-service-health:4.22
         imagePullPolicy: Always
         name: expense
         ports:

--- a/labs/deployments-health/application.yaml
+++ b/labs/deployments-health/application.yaml
@@ -19,7 +19,7 @@ spec:
         deployment: expense
     spec:
       containers:
-      - image: registry.lab.example.com:8443/redhattraining/ocpdev-expense-service-health:4.22
+      - image: registry.lab.example.com:8443/redhattraining/ocpdev-expense-service-health:4.18
         imagePullPolicy: Always
         name: expense
         ports:

--- a/labs/deployments-health/application.yaml
+++ b/labs/deployments-health/application.yaml
@@ -19,7 +19,7 @@ spec:
         deployment: expense
     spec:
       containers:
-      - image: registry.ocp4.example.com:8443/redhattraining/ocpdev-expense-service-health:4.18
+      - image: registry.lab.example.com:8443/redhattraining/ocpdev-expense-service-health:4.22
         imagePullPolicy: Always
         name: expense
         ports:
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: expense
   name: expense
 spec:
-  host: expense-deployments-health.apps.ocp4.example.com
+  host: expense-deployments-health.apps.lab.example.com
   port:
     targetPort: 8080-tcp
   to:


### PR DESCRIPTION
## Summary
- Update registry hostname from `registry.ocp4.example.com:8443` to `registry.lab.example.com:8443`
- Update route host from `apps.ocp4.example.com` to `apps.lab.example.com`
- Update image tag from `4.18` to `4.22`

## Linked Jiras
- [CDEV-18238](https://redhat.atlassian.net/browse/CDEV-18238) - GE - Monitoring Application Health

[CDEV-18238]: https://redhat.atlassian.net/browse/CDEV-18238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ