### PR TITLE
feat: Bump deployments-stateful to 4.22

### DIFF
--- a/kubefiles/deployments-stateful/mysql-deployment.yaml
+++ b/kubefiles/deployments-stateful/mysql-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - image: registry.ocp4.example.com:8443/rhel8/mysql-80
+      - image: registry.lab.example.com:8443/rhel8/mysql-80
         imagePullPolicy: Always
         name: mysql-80
         ports:

--- a/labs/deployments-stateful/mysql-stateful-set.yaml
+++ b/labs/deployments-stateful/mysql-stateful-set.yaml
@@ -13,7 +13,7 @@ spec:
         app: mysql-db
     spec:
       containers:
-      - image: registry.ocp4.example.com:8443/rhel8/mysql-80
+      - image: registry.lab.example.com:8443/rhel8/mysql-80
         name: mysql-80
         ports:
           - containerPort: 3306


### PR DESCRIPTION
## Summary
- Add lab materials for `deployments-stateful` exercise with classroom hostnames
- Registry hostname uses `registry.lab.example.com:8443` (updated from `registry.ocp4.example.com:8443`)

## Files added
- `labs/deployments-stateful/init-db.sql` — SQL script for database initialization
- `labs/deployments-stateful/mysql-stateful-set.yaml` — StatefulSet manifest with updated registry hostname