### PR TITLE
Rename ocp4.example.com to lab.example.com in deployments-stateful

### DIFF
--- a/kubefiles/deployments-stateful/mysql-deployment.yaml
+++ b/kubefiles/deployments-stateful/mysql-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - image: registry.ocp4.example.com:8443/rhel8/mysql-80
+      - image: registry.lab.example.com:8443/rhel8/mysql-80
         imagePullPolicy: Always
         name: mysql-80
         ports:

--- a/labs/deployments-stateful/mysql-stateful-set.yaml
+++ b/labs/deployments-stateful/mysql-stateful-set.yaml
@@ -13,7 +13,7 @@ spec:
         app: mysql-db
     spec:
       containers:
-      - image: registry.ocp4.example.com:8443/rhel8/mysql-80
+      - image: registry.lab.example.com:8443/rhel8/mysql-80
         name: mysql-80
         ports:
           - containerPort: 3306


### PR DESCRIPTION
## Summary
- Rename `registry.ocp4.example.com` to `registry.lab.example.com` in deployments-stateful kubefiles and lab manifests

## Test plan
- [ ] Verify deployment and statefulset pods start with the correct image