### PR TITLE
fix: Rename ocp4.example.com to lab.example.com in deployments-strategy

### DIFF
--- a/apps/deployments-strategy/users-db/Dockerfile
+++ b/apps/deployments-strategy/users-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ocp4.example.com:8443/rhel8/mysql-80
+FROM registry.lab.example.com:8443/rhel8/mysql-80
 
 COPY import.sh users.sql /post-deploy
 

--- a/solutions/deployments-strategy/application.yaml
+++ b/solutions/deployments-strategy/application.yaml
@@ -16,10 +16,10 @@ items:
       local: false
     tags:
     - annotations:
-        openshift.io/imported-from: registry.ocp4.example.com:8443/rhel8/mysql-80
+        openshift.io/imported-from: registry.lab.example.com:8443/rhel8/mysql-80
       from:
         kind: DockerImage
-        name: registry.ocp4.example.com:8443/rhel8/mysql-80
+        name: registry.lab.example.com:8443/rhel8/mysql-80
       generation: null
       importPolicy:
         importMode: Legacy
@@ -66,7 +66,7 @@ items:
     source:
       contextDir: apps/deployments-strategy/users-db
       git:
-        uri: https://git.ocp4.example.com/developer/DO288-apps
+        uri: https://git.lab.example.com/developer/DO288-apps
       type: Git
     strategy:
       dockerStrategy:


### PR DESCRIPTION
## Summary
- Update classroom hostnames from `ocp4.example.com` to `lab.example.com` in deployments-strategy exercise materials
- Applies to Dockerfile base image reference and solution manifest (registry, git URI)

## Changed Files
- `apps/deployments-strategy/users-db/Dockerfile` — base image registry hostname
- `solutions/deployments-strategy/application.yaml` — registry image refs (2) and git URI (1)

## Context
Companion to https://github.com/RedHatTraining/DO288/pull/1938 which applies the same rename in the main course repo's `ge.adoc`.