### PR TITLE
Update deployments-review host: ocp4.example.com → lab.example.com

### DIFF
--- a/apps/deployments-review/expense-service/src/main/docker/Dockerfile.fast-jar
+++ b/apps/deployments-review/expense-service/src/main/docker/Dockerfile.fast-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/expense-restful-service-jvm
 #
 ###
-FROM registry.ocp4.example.com:8443/ubi8/ubi-minimal:8.1
+FROM registry.lab.example.com:8443/ubi8/ubi-minimal:8.1
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/apps/deployments-review/expense-service/src/main/docker/Dockerfile.jvm
+++ b/apps/deployments-review/expense-service/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/expense-restful-service-jvm
 #
 ###
-FROM registry.ocp4.example.com:8443/ubi8/ubi-minimal:8.1
+FROM registry.lab.example.com:8443/ubi8/ubi-minimal:8.1
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/apps/deployments-review/expense-service/src/main/docker/Dockerfile.native
+++ b/apps/deployments-review/expense-service/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/expense-restful-service
 #
 ###
-FROM registry.ocp4.example.com:8443/ubi8/ubi-minimal:8.1
+FROM registry.lab.example.com:8443/ubi8/ubi-minimal:8.1
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
## Summary
- Replace `registry.ocp4.example.com:8443` with `registry.lab.example.com:8443` in the three Dockerfile variants for the `expense-service` application under `apps/deployments-review/`

## Files changed
- `apps/deployments-review/expense-service/src/main/docker/Dockerfile.jvm`
- `apps/deployments-review/expense-service/src/main/docker/Dockerfile.native`
- `apps/deployments-review/expense-service/src/main/docker/Dockerfile.fast-jar`

## Test plan
- [ ] Verify the container image builds with the updated registry reference